### PR TITLE
Run tox checks before commit

### DIFF
--- a/tests/inference_test.py
+++ b/tests/inference_test.py
@@ -337,9 +337,7 @@ class TestCustomLanguageModel(absltest.TestCase):
     mock_openai_class.return_value = mock_client
 
     custom_base_url = "https://custom-language-model.example.com/api/v1"
-    inference.CustomLanguageModel(
-        api_key="test-key", base_url=custom_base_url
-    )
+    inference.CustomLanguageModel(api_key="test-key", base_url=custom_base_url)
 
     # Verify OpenAI client was initialized with custom base URL
     mock_openai_class.assert_called_once_with(


### PR DESCRIPTION
# Description

Fixes a code formatting issue identified by `pyink` during `tox` checks.

The `format` tox environment was failing due to a multi-line function call in `tests/inference_test.py` that `pyink` expected to be on a single line. This PR resolves that formatting inconsistency.

Fixes #
Code health

# How Has This Been Tested?

The changes were verified by running the `tox` suite, specifically the `format` environment, which now passes.

```
$ tox -e format
```

# Checklist:

-   [x] I have read and acknowledged Google's Open Source
    [Code of conduct](https://opensource.google/conduct).
-   [x] I have read the
    [Contributing](https://github.com/google-health/langextract/blob/master/CONTRIBUTING.md)
    page, and I either signed the Google
    [Individual CLA](https://cla.developers.google.com/about/google-individual)
    or am covered by my company's
    [Corporate CLA](https://cla.developers.google.com/about/google-corporate).
-   [ ] I have discussed my proposed solution with code owners in the linked
    issue(s) and we have agreed upon the general approach.
-   [ ] I have made any needed documentation changes, or noted in the linked
    issue(s) that documentation elsewhere needs updating.
-   [x] I have added tests, or I have ensured existing tests cover the changes
-   [x] I have followed
    [Google's Python Style Guide](https://google.github.io/styleguide/pyguide.html)
    and ran `pylint` over the affected code.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f018581-2334-468a-83ad-76d220666dbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f018581-2334-468a-83ad-76d220666dbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>